### PR TITLE
Update Python version in Dockerfile and pyproject.toml

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.13
+FROM python:3.8.8-alpine3.13
 
 WORKDIR /srv
 

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -151,8 +151,8 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.8.7"
-content-hash = "71c2519eb9bd5ba247440b5e93c7b22f863115ce07cef1a33133fd8acc2a913f"
+python-versions = "3.8.8"
+content-hash = "ba1566e90cc8cca50ec9d41da8bb935b982aa311c268805d0fa9a7ae1247a812"
 
 [metadata.files]
 asgiref = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Shipyard <team@shipyard.build>"]
 
 [tool.poetry.dependencies]
-python = "3.8.7"
+python = "3.8.8"
 Django = "3.1.4"
 psycopg2-binary = "2.8.6"
 boto3 = "1.16.44"


### PR DESCRIPTION
Updated `Dockerfile` Python base image version to `python:3.8.8-alpine3.13` and updated Python version in `pyproject.toml` to match. This fixes a discrepancy that was preventing the project from building, as seen in the error message below:

```
Step 7/10 : RUN poetry install
 ---> Running in 8885d610c7ff
The currently activated Python version 3.8.8 is not supported by the project (3.8.7).
Trying to find and use a compatible version. 

  NoCompatiblePythonVersionFound

  Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.

  at /usr/local/lib/python3.8/site-packages/poetry/utils/env.py:735 in create_venv
       731│                     python_minor = ".".join(python_patch.split(".")[:2])
       732│                     break
       733│ 
       734│             if not executable:
    →  735│                 raise NoCompatiblePythonVersionFound(
       736│                     self._poetry.package.python_versions
       737│                 )
       738│ 
       739│         if root_venv:
ERROR: Service 'backend' failed to build : The command '/bin/sh -c poetry install' returned a non-zero code: 1
make: *** [build] Error 1
```